### PR TITLE
Display question title as label of node.

### DIFF
--- a/routeviz/routeviz.py
+++ b/routeviz/routeviz.py
@@ -5,7 +5,7 @@ import sys
 
 class Block:
 
-    def __init__(self, name):
+    def __init__(self, name=''):
         self.name = name
         self.routing_rules = None
 
@@ -25,7 +25,9 @@ def parse_schema_for_blocks(schema_json):
     for section in schema_json['sections']:
         for group in section['groups']:
             for block in group['blocks']:
-                b = Block(block['id'])
+                b = Block()
+                for question in block['questions']:
+                    b.name = question['title']
                 if 'routing_rules' in block:
                     b.routing_rules = block['routing_rules']
                 blocks.append(b)


### PR DESCRIPTION
### Description
This PR makes changes to the way that nodes are displayed.
It uses the label of the question, instead of the block Id as can be seen below.
There's still a limitation here that if there's more than one question on a block, the last question label will be used.

However this limitation is somewhat mitigated since having more than one question per block is a bad pattern and should generally be discouraged.

![image](https://user-images.githubusercontent.com/4097796/37835426-0ab74e8e-2ea8-11e8-8ec2-f92c5941b3eb.png)
